### PR TITLE
Refactor: simplify constants imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ import (
 	"os"
 
 	deepseek "github.com/cohesion-org/deepseek-go"
-	constants "github.com/cohesion-org/deepseek-go/constants"
+	
 )
 
 func main() {
@@ -78,8 +78,8 @@ func main() {
 	request := &deepseek.ChatCompletionRequest{
 		Model: deepseek.DeepSeekChat,
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleSystem, Content: "Answer every question using slang."},
-			{Role: constants.ChatMessageRoleUser, Content: "Which is the tallest mountain in the world?"},
+			{Role: deepseek.ChatMessageRoleSystem, Content: "Answer every question using slang."},
+			{Role: deepseek.ChatMessageRoleUser, Content: "Which is the tallest mountain in the world?"},
 		},
 	}
 
@@ -111,7 +111,6 @@ import (
 	"os"
 
 	deepseek "github.com/cohesion-org/deepseek-go"
-	constants "github.com/cohesion-org/deepseek-go/constants"
 )
 
 func main() {
@@ -130,7 +129,7 @@ func main() {
 		Model: deepseek.AzureDeepSeekR1,
 		// Model: deepseek.OpenRouterDeepSeekR1,
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: "Which is the tallest mountain in the world?"},
+			{Role: deepseek.ChatMessageRoleUser, Content: "Which is the tallest mountain in the world?"},
 		},
 	}
 
@@ -159,8 +158,8 @@ Note: If you wish to use other providers that are not supported by us, you can s
 	request := &deepseek.ChatCompletionRequest{
 		Model: deepseek.DeepSeekChat,
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: "What is the meaning of deepseek"},
-			{Role: constants.ChatMessageRoleSystem, Content: "Answer every question using slang"},
+			{Role: deepseek.ChatMessageRoleUser, Content: "What is the meaning of deepseek"},
+			{Role: deepseek.ChatMessageRoleSystem, Content: "Answer every question using slang"},
 		},
 		Temperature: 1.0,
 		Stop:        []string{"yo", "hello"},
@@ -183,7 +182,6 @@ import (
 	"log"
 
 	deepseek "github.com/cohesion-org/deepseek-go"
-	"github.com/cohesion-org/deepseek-go/constants"
 )
 
 func MultiChat() {
@@ -191,7 +189,7 @@ func MultiChat() {
 	ctx := context.Background()
 
 	messages := []deepseek.ChatCompletionMessage{{
-		Role:    constants.ChatMessageRoleUser,
+		Role:    deepseek.ChatMessageRoleUser,
 		Content: "Who is the president of the United States? One word response only.",
 	}}
 
@@ -213,7 +211,7 @@ func MultiChat() {
 	log.Printf("The messages after response 1 are: %v", messages)
 	// Round 2: Second API call
 	messages = append(messages, deepseek.ChatCompletionMessage{
-		Role:    constants.ChatMessageRoleUser,
+		Role:    deepseek.ChatMessageRoleUser,
 		Content: "Who was the one in the previous term.",
 	})
 
@@ -253,7 +251,6 @@ import (
 	"os"
 
 	deepseek "github.com/cohesion-org/deepseek-go"
-	constants "github.com/cohesion-org/deepseek-go/constants"
 )
 
 func main() {
@@ -261,7 +258,7 @@ func main() {
 	request := &deepseek.StreamChatCompletionRequest{
 		Model: deepseek.DeepSeekChat,
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: "Just testing if the streaming feature is working or not!"},
+			{Role: deepseek.ChatMessageRoleUser, Content: "Just testing if the streaming feature is working or not!"},
 		},
 		Stream: true,
 	}
@@ -354,8 +351,8 @@ func Estimation() {
 	request := &deepseek.ChatCompletionRequest{
 		Model: deepseek.DeepSeekChat,
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleSystem, Content: "Just respond with the time it might take you to complete this request."},
-			{Role: constants.ChatMessageRoleUser, Content: "The text to evaluate the time is: Who is the greatest singer in the world?"},
+			{Role: deepseek.ChatMessageRoleSystem, Content: "Just respond with the time it might take you to complete this request."},
+			{Role: deepseek.ChatMessageRoleUser, Content: "The text to evaluate the time is: Who is the greatest singer in the world?"},
 		},
 	}
 	ctx := context.Background()
@@ -388,8 +385,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/cohesion-org/deepseek-go"
-	"github.com/cohesion-org/deepseek-go/constants"
+	deepseek "github.com/cohesion-org/deepseek-go"
 )
 
 func JsonMode() {
@@ -420,7 +416,7 @@ func JsonMode() {
 	resp, err := client.CreateChatCompletion(ctx, &deepseek.ChatCompletionRequest{
 		Model: "mistralai/codestral-2501", // Or another suitable model
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: prompt},
+			{Role: deepseek.ChatMessageRoleUser, Content: prompt},
 		},
 		JSONMode: true,
 	})
@@ -530,7 +526,6 @@ import (
 	"log"
 
 	deepseek "github.com/cohesion-org/deepseek-go"
-	"github.com/cohesion-org/deepseek-go/constants"
 )
 
 func ChatPrefix() {
@@ -543,8 +538,8 @@ func ChatPrefix() {
 	request := &deepseek.ChatCompletionRequest{
 		Model: deepseek.DeepSeekChat,
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: "Please write quick sort code"},
-			{Role: constants.ChatMessageRoleAssistant, Content: "```python", Prefix: true},
+			{Role: deepseek.ChatMessageRoleUser, Content: "Please write quick sort code"},
+			{Role: deepseek.ChatMessageRoleAssistant, Content: "```python", Prefix: true},
 		},
 		Stop: []string{"```"}, // Stop the prefix when the assistant sends the closing triple backticks
 	}

--- a/chat.go
+++ b/chat.go
@@ -2,6 +2,17 @@ package deepseek
 
 import (
 	"errors"
+
+	"github.com/cohesion-org/deepseek-go/constants"
+)
+
+const (
+	// ChatMessageRoleSystem is the role of a system message
+	ChatMessageRoleSystem = constants.ChatMessageRoleSystem
+	// ChatMessageRoleUser is the role of a user message
+	ChatMessageRoleUser = constants.ChatMessageRoleUser
+	// ChatMessageRoleAssistant is the role of an assistant message
+	ChatMessageRoleAssistant = constants.ChatMessageRoleAssistant
 )
 
 var (

--- a/examples/00_external_providers/chat.go
+++ b/examples/00_external_providers/chat.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	deepseek "github.com/cohesion-org/deepseek-go"
-	constants "github.com/cohesion-org/deepseek-go/constants"
 )
 
 // ExternalProviders demonstrates how to use the Deepseek client with external providers.
@@ -32,7 +31,7 @@ func ExternalProviders() {
 		Model: deepseek.AzureDeepSeekR1,
 		// Model: deepseek.OpenRouterDeepSeekR1,
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: "Which is the tallest mountain in the world?"},
+			{Role: deepseek.ChatMessageRoleUser, Content: "Which is the tallest mountain in the world?"},
 		},
 	}
 

--- a/examples/01_chat/chat.go
+++ b/examples/01_chat/chat.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	deepseek "github.com/cohesion-org/deepseek-go"
-	"github.com/cohesion-org/deepseek-go/constants"
 )
 
 func Chat() {
@@ -15,8 +14,8 @@ func Chat() {
 	request := &deepseek.ChatCompletionRequest{
 		Model: deepseek.DeepSeekChat,
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: "Which is the tallest mountain in the world?"},
-			{Role: constants.ChatMessageRoleSystem, Content: "Answer every question using slang"},
+			{Role: deepseek.ChatMessageRoleUser, Content: "Which is the tallest mountain in the world?"},
+			{Role: deepseek.ChatMessageRoleSystem, Content: "Answer every question using slang"},
 		},
 	}
 	ctx := context.Background()

--- a/examples/02_chat_stream/chat_stream.go
+++ b/examples/02_chat_stream/chat_stream.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	deepseek "github.com/cohesion-org/deepseek-go"
-	"github.com/cohesion-org/deepseek-go/constants"
 )
 
 // Streaming function demonstrates how to use the streaming feature of the DeepSeek API for chat completion.
@@ -18,7 +17,7 @@ func Streaming() {
 	request := &deepseek.StreamChatCompletionRequest{
 		Model: deepseek.DeepSeekChat,
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: "Just testing if the streaming feature is working or not!"},
+			{Role: deepseek.ChatMessageRoleUser, Content: "Just testing if the streaming feature is working or not!"},
 		},
 		Stream: true,
 	}
@@ -54,7 +53,7 @@ func StreamingWithReasoningContent() {
 	request := &deepseek.StreamChatCompletionRequest{
 		Model: deepseek.DeepSeekReasoner,
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: "Hello, how are you?"},
+			{Role: deepseek.ChatMessageRoleUser, Content: "Hello, how are you?"},
 		},
 		Stream: true,
 	}

--- a/examples/04_json_mode/json_mode.go
+++ b/examples/04_json_mode/json_mode.go
@@ -6,8 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/cohesion-org/deepseek-go"
-	"github.com/cohesion-org/deepseek-go/constants"
+	deepseek "github.com/cohesion-org/deepseek-go"
 )
 
 // JsonMode is a client specific feature that demonstrates how to use the JSON mode for chat completion.
@@ -39,7 +38,7 @@ func JsonMode() {
 	resp, err := client.CreateChatCompletion(ctx, &deepseek.ChatCompletionRequest{
 		Model: "mistralai/codestral-2501", // Or another suitable model
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: prompt},
+			{Role: deepseek.ChatMessageRoleUser, Content: prompt},
 		},
 		JSONMode: true,
 	})
@@ -98,7 +97,7 @@ Example: {"isbn": "978-0321765723", "title": "The Lord of the Rings", "author": 
 	resp, err := client.CreateChatCompletion(ctx, &deepseek.ChatCompletionRequest{
 		Model: "mistralai/codestral-2501", // Or another suitable model
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: prompt},
+			{Role: deepseek.ChatMessageRoleUser, Content: prompt},
 		},
 		JSONMode: true,
 	})

--- a/examples/05_multi_chat/multi_chat.go
+++ b/examples/05_multi_chat/multi_chat.go
@@ -5,7 +5,6 @@ import (
 	"log"
 
 	deepseek "github.com/cohesion-org/deepseek-go"
-	"github.com/cohesion-org/deepseek-go/constants"
 )
 
 func MultiChat() {
@@ -13,7 +12,7 @@ func MultiChat() {
 	ctx := context.Background()
 
 	messages := []deepseek.ChatCompletionMessage{{
-		Role:    constants.ChatMessageRoleUser,
+		Role:    deepseek.ChatMessageRoleUser,
 		Content: "Who is the president of the United States? One word response only.",
 	}}
 
@@ -35,7 +34,7 @@ func MultiChat() {
 	log.Printf("The messages after response 1 are: %v", messages)
 	// Round 2: Second API call
 	messages = append(messages, deepseek.ChatCompletionMessage{
-		Role:    constants.ChatMessageRoleUser,
+		Role:    deepseek.ChatMessageRoleUser,
 		Content: "Who was the one in the previous term.",
 	})
 

--- a/examples/05_multi_chat/multi_chat_stream.go
+++ b/examples/05_multi_chat/multi_chat_stream.go
@@ -7,7 +7,6 @@ import (
 	"log"
 
 	deepseek "github.com/cohesion-org/deepseek-go"
-	constants "github.com/cohesion-org/deepseek-go/constants"
 )
 
 // MultiChatStream demonstrates how to use the ChatStream API for multi-turn chat completion.
@@ -16,7 +15,7 @@ func MultiChatStream() {
 	ctx := context.Background()
 
 	messages := []deepseek.ChatCompletionMessage{{
-		Role:    constants.ChatMessageRoleUser,
+		Role:    deepseek.ChatMessageRoleUser,
 		Content: "What's the highest mountain in the world? One word response only.",
 	}}
 
@@ -28,7 +27,7 @@ func MultiChatStream() {
 
 	// can't use mappers here to append to messages because the response is a stream
 	messages = append(messages, deepseek.ChatCompletionMessage{
-		Role:    constants.ChatMessageRoleAssistant,
+		Role:    deepseek.ChatMessageRoleAssistant,
 		Content: response1,
 	})
 
@@ -36,7 +35,7 @@ func MultiChatStream() {
 
 	// Second round of conversation
 	messages = append(messages, deepseek.ChatCompletionMessage{
-		Role:    constants.ChatMessageRoleUser,
+		Role:    deepseek.ChatMessageRoleUser,
 		Content: "What is the second?",
 	})
 
@@ -46,7 +45,7 @@ func MultiChatStream() {
 	}
 
 	messages = append(messages, deepseek.ChatCompletionMessage{
-		Role:    constants.ChatMessageRoleAssistant,
+		Role:    deepseek.ChatMessageRoleAssistant,
 		Content: response2,
 	})
 

--- a/examples/06_bad_multi_chat/bad_multi_chat.go
+++ b/examples/06_bad_multi_chat/bad_multi_chat.go
@@ -8,7 +8,6 @@ import (
 	"log"
 
 	deepseek "github.com/cohesion-org/deepseek-go"
-	"github.com/cohesion-org/deepseek-go/constants"
 )
 
 // BadMultiChat shows an outdated way of creating a multi-chat completion
@@ -17,7 +16,7 @@ func BadMultiChat() {
 	ctx := context.Background()
 
 	messages := []deepseek.ChatCompletionMessage{{
-		Role:    constants.ChatMessageRoleUser,
+		Role:    deepseek.ChatMessageRoleUser,
 		Content: "What's the highest mountain in the world? One word response only.",
 	}}
 
@@ -37,7 +36,7 @@ func BadMultiChat() {
 	fmt.Printf("Messages after Round 1: %+v\n", messages)
 
 	messages = append(messages, deepseek.ChatCompletionMessage{
-		Role:    constants.ChatMessageRoleUser,
+		Role:    deepseek.ChatMessageRoleUser,
 		Content: "What is the second?",
 	})
 

--- a/examples/09_prefix_completion/prefix_completion.go
+++ b/examples/09_prefix_completion/prefix_completion.go
@@ -9,7 +9,6 @@ import (
 	"os"
 
 	deepseek "github.com/cohesion-org/deepseek-go"
-	"github.com/cohesion-org/deepseek-go/constants"
 )
 
 // ChatPrefix demonstrates how to use the Chat API for Chat completion with a prefix.
@@ -23,8 +22,8 @@ func ChatPrefix() {
 	request := &deepseek.ChatCompletionRequest{
 		Model: deepseek.DeepSeekChat,
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: "Please write quick sort code"},
-			{Role: constants.ChatMessageRoleAssistant, Content: "```python\n", Prefix: true},
+			{Role: deepseek.ChatMessageRoleUser, Content: "Please write quick sort code"},
+			{Role: deepseek.ChatMessageRoleAssistant, Content: "```python\n", Prefix: true},
 		},
 		Stop: []string{"```"}, // Stop the prefix when the assistant sends the closing triple backticks
 	}
@@ -65,8 +64,8 @@ func ChatPrefixWithJsonMode() {
 	resp, err := client.CreateChatCompletion(ctx, &deepseek.ChatCompletionRequest{
 		Model: deepseek.DeepSeekChat,
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: prompt},
-			{Role: constants.ChatMessageRoleAssistant, Content: "```json\n", Prefix: true},
+			{Role: deepseek.ChatMessageRoleUser, Content: prompt},
+			{Role: deepseek.ChatMessageRoleAssistant, Content: "```json\n", Prefix: true},
 		},
 		Stop:     []string{"```"}, // Stop the prefix when the assistant sends the closing triple backticks
 		JSONMode: true,

--- a/examples/10_token_usage/token_usage.go
+++ b/examples/10_token_usage/token_usage.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	deepseek "github.com/cohesion-org/deepseek-go"
-	constants "github.com/cohesion-org/deepseek-go/constants"
 )
 
 // EstimateTokens demonstrates how to estimate the tokens used for a request.
@@ -16,7 +15,7 @@ func EstimateTokens() {
 	request := &deepseek.ChatCompletionRequest{
 		Model: deepseek.DeepSeekChat,
 		Messages: []deepseek.ChatCompletionMessage{
-			{Role: constants.ChatMessageRoleUser, Content: "The text to evaluate the time is: Who is the greatest singer in the world?"},
+			{Role: deepseek.ChatMessageRoleUser, Content: "The text to evaluate the time is: Who is the greatest singer in the world?"},
 		},
 	}
 	ctx := context.Background()


### PR DESCRIPTION
**Summary:**  
This pull request refactors the handling of chat message roles in the `deepseek` package by simplifying the import structure. The constants for chat message roles, previously imported from the `deepseek-go/constants` package, are now redefined within the `chat.go` file for improved accessibility and cleaner imports.

**Key changes:**  
- Merged the constants into `chat.go` to avoid redundant imports.
- Defined `ChatMessageRoleSystem`, `ChatMessageRoleUser`, and `ChatMessageRoleAssistant` in `chat.go`, with values sourced from `constants`.
- Simplified the import statement by eliminating the need to separately import `constants`.

**Import example:**

*Before:*

```go
import (
	"fmt"
	"log"
	"os"

	deepseek "github.com/cohesion-org/deepseek-go"
	constants "github.com/cohesion-org/deepseek-go/constants"
)
```

*After:*

```go
import (
	"fmt"
	"log"
	"os"

	deepseek "github.com/cohesion-org/deepseek-go"
)
```

If desired, I can update the examples and the `README` to reflect these changes and make the transition clearer for users.

These changes will allow users to access constants directly from the main `deepseek` module, while maintaining backward compatibility with the `constants` package.