### PR TITLE
feat: allow the user to customize the http client

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,6 +17,12 @@ func (c *Client) CreateChatCompletion(
 		return nil, fmt.Errorf("request cannot be nil")
 	}
 
+	ctx, tcancel, err := getTimeoutContext(ctx, c.Timeout)
+	if err != nil {
+		return nil, err
+	}
+	defer tcancel()
+
 	req, err := utils.NewRequestBuilder(c.AuthToken).
 		SetBaseURL(c.BaseURL).
 		SetPath(c.Path).
@@ -51,6 +57,15 @@ func (c *Client) CreateChatCompletionStream(
 	ctx context.Context,
 	request *StreamChatCompletionRequest,
 ) (ChatCompletionStream, error) {
+	if request == nil {
+		return nil, fmt.Errorf("request cannot be nil")
+	}
+
+	ctx, tcancel, err := getTimeoutContext(ctx, c.Timeout)
+	if err != nil {
+		return nil, err
+	}
+	defer tcancel()
 
 	request.Stream = true
 	req, err := utils.NewRequestBuilder(c.AuthToken).

--- a/config.go
+++ b/config.go
@@ -21,6 +21,8 @@ type Client struct {
 	BaseURL   string        // The base URL for the API
 	Timeout   time.Duration // The timeout for the current Client
 	Path      string        // The path for the API request. Defaults to "chat/completions"
+
+	HTTPClient HTTPDoer // The HTTP client to send the request and get the response
 }
 
 // NewClient creates a new client with an authentication token and an optional custom baseURL.
@@ -112,6 +114,14 @@ func WithPath(path string) Option {
 	}
 	return func(c *Client) error {
 		c.Path = path
+		return nil
+	}
+}
+
+// WithHTTPClient sets the http client for the API client.
+func WithHTTPClient(httpclient HTTPDoer) Option {
+	return func(c *Client) error {
+		c.HTTPClient = httpclient
 		return nil
 	}
 }

--- a/requestHandler.go
+++ b/requestHandler.go
@@ -76,5 +76,11 @@ func (c *Client) handleRequest(req *http.Request) (*http.Response, error) {
 	if client == nil {
 		client = http.DefaultClient
 	}
-	return client.Do(req)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error sending request: %w", err)
+	}
+
+	return resp, nil
 }


### PR DESCRIPTION
## Feature

1. Allow the user to customize `http.Client`, not the fixed `&http.Client{Timeout: timeout}`. 
    If not configuring the http client, use `http.DefaultClient` instead.
2. For the original timeout config, use the timeout context `context.WithTimeout` to support it.

## Motivation

The user maybe configure the proxy by the user-defined `http.Client`.