### PR TITLE
fix: position of TopLogprobs in LogProbs

### DIFF
--- a/responseHandler.go
+++ b/responseHandler.go
@@ -51,15 +51,15 @@ type Message struct {
 
 // Logprobs represents log probability information for a choice or token.
 type Logprobs struct {
-	Content     []ContentToken    `json:"content"`      // A list of message content tokens with log probability information.
-	TopLogprobs []TopLogprobToken `json:"top_logprobs"` // List of the most likely tokens and their log probability.
+	Content []ContentToken `json:"content"` // A list of message content tokens with log probability information.
 }
 
 // ContentToken represents a single token within the content with its log probability and byte information.
 type ContentToken struct {
-	Token   string  `json:"token"`           // The token string.
-	Logprob float64 `json:"logprob"`         // The log probability of this token. -9999.0 if not in top 20.
-	Bytes   []int   `json:"bytes,omitempty"` // UTF-8 byte representation of the token. Can be nil.
+	Token       string            `json:"token"`           // The token string.
+	Logprob     float64           `json:"logprob"`         // The log probability of this token. -9999.0 if not in top 20.
+	Bytes       []int             `json:"bytes,omitempty"` // UTF-8 byte representation of the token. Can be nil.
+	TopLogprobs []TopLogprobToken `json:"top_logprobs"`    // List of the most likely tokens and their log probability.
 }
 
 // TopLogprobToken represents a single token within the top log probabilities with its log probability and byte information.


### PR DESCRIPTION
## Description
This pr addresses an issue with the positioning of TopLogProbs within LogProbs to ensure compatibility with the API output.
### After:
![image](https://github.com/user-attachments/assets/d83bbe1d-12cc-432b-a4ff-71a2c003b28d)

### API reference:
https://api-docs.deepseek.com/api/create-chat-completion
![image](https://github.com/user-attachments/assets/478eb1b9-7ce8-43ee-93b6-6e0fb5bcb0c4)
