### PR TITLE
Fixes edge case with absolute path

### DIFF
--- a/image.go
+++ b/image.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -196,9 +195,8 @@ func ImageToBase64(imageURL string) (string, error) {
 		return "", fmt.Errorf("unsupported image format: %s", ext)
 	}
 
-	//Check if the imageURL is a valid URL or a path to a local file
-	if _, err := url.ParseRequestURI(imageURL); err == nil {
-		// If it's a valid URL, download the image and convert it to base64
+	// Check if the imageURL is a web URL by looking for http(s) prefix
+	if strings.HasPrefix(imageURL, "http://") || strings.HasPrefix(imageURL, "https://") {
 		return handleImageFromURL(imageURL)
 	}
 

--- a/image_test.go
+++ b/image_test.go
@@ -232,6 +232,12 @@ func TestImageToBase64Encoding(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "Local image full path",
+			imgURL:  "/Users/vein/Downloads/wallpapers/PINK-FLOYD.png",
+			want:    "data:image/png;base64,",
+			wantErr: false,
+		},
+		{
 			name:    "WebP image from Google",
 			imgURL:  "https://www.gstatic.com/webp/gallery/1.webp",
 			want:    "data:image/webp;base64,",


### PR DESCRIPTION
Issue: url.ParseRequestURI() incorrectly handles absolute file paths as valid URLs

Problem
When using url.ParseRequestURI() to validate URLs for image processing, the function incorrectly returns success (nil error) for absolute file paths (e.g., /usr/local/images/photo.jpg) because it considers them valid URI paths according to RFC 3986. This caused the code to attempt downloading local files as if they were web URLs.

Impact
- Local file paths were being mistakenly treated as web URLs
- Unnecessary HTTP requests were being made for local files
- Failed image processing when using absolute paths

Solution
Replace the url.ParseRequestURI() check with an explicit HTTP(S) prefix check:

Technical Details
- The URI specification (RFC 3986) considers absolute paths starting with "/" as valid URI paths
- url.ParseRequestURI() follows this specification, making it unsuitable for distinguishing between web URLs and file paths
- Using strings.HasPrefix() provides a more explicit and accurate way to identify web URLs

Testing
- Test with absolute file paths (e.g., /usr/local/images/photo.jpg)
- Test with relative file paths (e.g., ./images/photo.jpg)
- Test with HTTP URLs (e.g., http://example.com/photo.jpg)
- Test with HTTPS URLs (e.g., https://example.com/photo.jpg)

Resolves: #54