### PR TITLE
#61 feat: improve error handling in NewClient in case of missing api key

### DIFF
--- a/config.go
+++ b/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 )
 
@@ -30,7 +31,12 @@ type Client struct {
 // You can't set path with this method. If you want to set path, use NewClientWithOptions.
 func NewClient(AuthToken string, baseURL ...string) *Client {
 	if AuthToken == "" {
-		return nil
+		if envKey, ok := os.LookupEnv("DEEPSEEK_API_KEY"); ok && envKey != "" {
+			AuthToken = envKey
+		} else {
+			fmt.Printf("authToken is empty. Please provide a valid token or set the DEEPSEEK_API_KEY environment variable")
+			return nil
+		}
 	}
 	// check if this is a valid URL
 	if len(baseURL) > 0 {

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package deepseek_test
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -11,6 +12,23 @@ import (
 
 func TestNewCleint(t *testing.T) {
 	testutil.SkipIfShort(t)
+	// test empty api key with no env fallback
+	t.Run("empty api key with no env fallback", func(t *testing.T) {
+		os.Unsetenv("DEEPSEEK_API_KEY")
+		client := deepseek.NewClient("")
+		require.Nil(t, client)
+	})
+
+	// test empty api key with env fallback
+	t.Run("empty api key with env fallback", func(t *testing.T) {
+		os.Setenv("DEEPSEEK_API_KEY", "test")
+		defer os.Unsetenv("DEEPSEEK_API_KEY")
+
+		client := deepseek.NewClient("")
+		require.NotNil(t, client)
+		require.Equal(t, "test", client.AuthToken)
+	})
+
 	//test empty api key
 	client := deepseek.NewClient("")
 	require.Nil(t, client)


### PR DESCRIPTION
Fix the issue where `deepseek.NewClient` does not properly handle an empty API key. After this change:

1. If the API key is empty, the function now looks up the `DEEPSEEK_API_KEY `environment variable using os.LookupEnv
2. If both the provided API key and environment variable are empty, the function logs a message notifying the user that no API key has been set

also included unit tests for this change