### PR TITLE
Reasoning open router

### DIFF
--- a/responseHandler_test.go
+++ b/responseHandler_test.go
@@ -69,6 +69,102 @@ func TestHandleChatCompletionResponse(t *testing.T) {
 			want: &validResponse,
 		},
 		{
+			name: "reasoning_content present",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(bytes.NewReader([]byte(`{
+                    "id": "chat-456",
+                    "object": "chat.completion",
+                    "created": 1677858243,
+                    "model": "deepseek-chat",
+                    "choices": [{
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Here is the answer.",
+                            "reasoning_content": "This is my reasoning."
+                        },
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {
+                        "prompt_tokens": 5,
+                        "completion_tokens": 10,
+                        "total_tokens": 15
+                    }
+                }`))),
+			},
+			want: &deepseek.ChatCompletionResponse{
+				ID:      "chat-456",
+				Object:  "chat.completion",
+				Created: 1677858243,
+				Model:   "deepseek-chat",
+				Choices: []deepseek.Choice{
+					{
+						Index: 0,
+						Message: deepseek.Message{
+							Role:             "assistant",
+							Content:          "Here is the answer.",
+							ReasoningContent: "This is my reasoning.",
+						},
+						FinishReason: "stop",
+					},
+				},
+				Usage: deepseek.Usage{
+					PromptTokens:     5,
+					CompletionTokens: 10,
+					TotalTokens:      15,
+				},
+			},
+		},
+		{
+			name: "reasoning present (OpenRouter style)",
+			response: &http.Response{
+				StatusCode: http.StatusOK,
+				Body: io.NopCloser(bytes.NewReader([]byte(`{
+                    "id": "chat-789",
+                    "object": "chat.completion",
+                    "created": 1677858244,
+                    "model": "deepseek-chat",
+                    "choices": [{
+                        "index": 0,
+                        "message": {
+                            "role": "assistant",
+                            "content": "Here is another answer.",
+                            "reasoning": "This is my OpenRouter reasoning."
+                        },
+                        "finish_reason": "stop"
+                    }],
+                    "usage": {
+                        "prompt_tokens": 6,
+                        "completion_tokens": 12,
+                        "total_tokens": 18
+                    }
+                }`))),
+			},
+			want: &deepseek.ChatCompletionResponse{
+				ID:      "chat-789",
+				Object:  "chat.completion",
+				Created: 1677858244,
+				Model:   "deepseek-chat",
+				Choices: []deepseek.Choice{
+					{
+						Index: 0,
+						Message: deepseek.Message{
+							Role:             "assistant",
+							Content:          "Here is another answer.",
+							ReasoningContent: "This is my OpenRouter reasoning.",
+						},
+						FinishReason: "stop",
+					},
+				},
+				Usage: deepseek.Usage{
+					PromptTokens:     6,
+					CompletionTokens: 12,
+					TotalTokens:      18,
+				},
+			},
+		},
+		{
 			name: "invalid JSON",
 			response: &http.Response{
 				StatusCode: http.StatusOK,


### PR DESCRIPTION
This pull request introduces changes to improve compatibility with different API response formats by adding custom JSON unmarshaling logic and updating related test cases. The most important changes include adding support for both `reasoning_content` and `reasoning` fields in API responses, modifying the `Logprobs` type, and enhancing test coverage.

### Compatibility Enhancements:
* Added custom `UnmarshalJSON` methods to the `StreamDelta` and `Message` structs to handle both `reasoning_content` and `reasoning` fields, with preference for `reasoning_content` when both are present. This ensures compatibility with APIs that use different field names for reasoning data. (`chat_stream.go` [[1]](diffhunk://#diff-08ece6ea6b76366f8c30994f1e4be44be5bac27651e2196b4d95df1e1417a9bcR60-R85) `responseHandler.go` [[2]](diffhunk://#diff-e17dcaff3f2da1584b7728b6a6a33e484e1d0b5213048395814e2d459b65af6fR52-R72)

### Code Simplifications:
* Updated the `Logprobs` field in the `StreamChoices` struct to use the `any` type instead of a specific `Logprobs` type, simplifying the handling of log probability data. (`chat_stream.go` [chat_stream.goR60-R85](diffhunk://#diff-08ece6ea6b76366f8c30994f1e4be44be5bac27651e2196b4d95df1e1417a9bcR60-R85))

### Test Coverage Improvements:
* Added test cases to verify proper handling of both `reasoning_content` and `reasoning` fields in API responses, ensuring the new unmarshaling logic works as intended. (`responseHandler_test.go` [responseHandler_test.goR71-R166](diffhunk://#diff-47521497b9a78d5049b92ed19768df0a3a369cd54ba583756622b0311ff1fbcfR71-R166))