### PR TITLE
models: add Requesty external provider constants

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ deepseek-go currently uses `go 1.26.0`
 - **Tool Calling**: Function calling with standard and strict mode (beta, with automatic `/beta` routing).
 - **FIM Completion**: Fill-in-the-Middle completions for code generation, with streaming.
 - **JSON Output**: Structured JSON output with schema extraction via `ResponseFormat`.
-- **External Providers**: OpenRouter, Azure, Ollama, and any OpenAI-compatible endpoint.
+- **External Providers**: OpenRouter, Requesty, Azure, Ollama, and any OpenAI-compatible endpoint.
 - **Balance & Models**: Check account balance and list available models.
 - **Token Estimation**: Client-side token counting for Chinese and English text.
 - **Modular Design**: Reusable components for building, sending, and handling requests and responses.
@@ -91,6 +91,10 @@ Before using the library, ensure you have:
 - **OpenRouter** <br/>
 	OpenRouter provides access to DeepSeek R1 and distill models. <br/>
 	Usage: `Model: deepseek.OpenRouterDeepSeekR1` (and other `OpenRouterDeepSeek*` constants)
+
+- **Requesty** <br/>
+	[Requesty](https://requesty.ai) is an OpenAI-compatible gateway. Set the client baseURL to `https://router.requesty.ai/v1/` and use a Requesty API key. <br/>
+	Usage: `Model: deepseek.RequestyDeepSeekV4Flash` (and `deepseek.RequestyDeepSeekChat`)
 
 - **Ollama Support** <br/>
 	Please read [Ollama Support](#ollama) for more info about this!

--- a/examples/00_external_providers/chat.go
+++ b/examples/00_external_providers/chat.go
@@ -23,6 +23,10 @@ func ExternalProviders() {
 	// OpenRouter
 	// baseURL := "https://openrouter.ai/api/v1/"
 
+	// Requesty (OpenAI-compatible gateway, https://requesty.ai)
+	// baseURL := "https://router.requesty.ai/v1/"
+	// then: Model: deepseek.RequestyDeepSeekV4Flash
+
 	// Set up the Deepseek client
 	client := deepseek.NewClient(os.Getenv("PROVIDER_API_KEY"), baseURL)
 

--- a/models.go
+++ b/models.go
@@ -29,6 +29,12 @@ const (
 	OpenRouterDeepSeekR1DistillQwen14B  = "deepseek/deepseek-r1-distill-qwen-14b"  // DeepSeek R1 Distill Qwen 14B
 	OpenRouterDeepSeekR1DistillQwen1_5B = "deepseek/deepseek-r1-distill-qwen-1.5b" // DeepSeek R1 Distill Qwen 1.5B
 	OpenRouterDeepSeekR1DistillQwen32B  = "deepseek/deepseek-r1-distill-qwen-32b"  // DeepSeek R1 Distill Qwen 32B
+
+	// Requesty (https://requesty.ai) is an OpenAI-compatible gateway; set the
+	// client baseURL to "https://router.requesty.ai/v1/" and authenticate with a
+	// Requesty API key. Models use the provider/model naming convention.
+	RequestyDeepSeekChat    = "deepseek/deepseek-chat"     // Requesty model for DeepSeek (chat)
+	RequestyDeepSeekV4Flash = "deepseek/deepseek-v4-flash" // Requesty model for DeepSeek V4 Flash
 )
 
 // Model represents a model that can be used with the API


### PR DESCRIPTION
## What

Adds [Requesty](https://requesty.ai) to the external-provider support, mirroring the existing OpenRouter path. Requesty is an OpenAI-compatible gateway, so it works by pointing the client baseURL at `https://router.requesty.ai/v1/` with a Requesty API key.

- `models.go`: `RequestyDeepSeekChat` and `RequestyDeepSeekV4Flash` constants
- `examples/00_external_providers/chat.go`: commented Requesty baseURL option (alongside the Azure/OpenRouter ones)
- `README.md`: Requesty bullet under External Providers + the features list

## Tested

- `go build ./...`, `go vet ./...`, `gofmt` — clean
- `go test -short ./...` — pass
- **Live**: `deepseek.NewClient(key, "https://router.requesty.ai/v1/")` with `deepseek.RequestyDeepSeekV4Flash` returns a valid completion.

I limited the constants to model slugs I verified actually route on Requesty (`deepseek/deepseek-chat`, `deepseek/deepseek-v4-flash`), rather than copying every OpenRouter R1 slug.

## Disclosure

I work at Requesty. This mirrors the existing OpenRouter external-provider pattern. Happy to adjust naming/placement or close if it's not a fit.