### PR TITLE
feat: add MiniMax external provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ Before using the library, ensure you have:
 	OpenRouter provides access to DeepSeek R1 and distill models. <br/>
 	Usage: `Model: deepseek.OpenRouterDeepSeekR1` (and other `OpenRouterDeepSeek*` constants)
 
+- **MiniMax** <br/>
+	MiniMax exposes an OpenAI-compatible endpoint (`https://api.minimax.io/v1/`). <br/>
+	Usage: `Model: deepseek.MiniMaxM3`
+
 - **Ollama Support** <br/>
 	Please read [Ollama Support](#ollama) for more info about this!
 
@@ -162,6 +166,9 @@ func main() {
 	// OpenRouter
 	// baseURL := "https://openrouter.ai/api/v1/"
 
+	// MiniMax
+	// baseURL := "https://api.minimax.io/v1/"
+
 	// Set up the Deepseek client
     client := deepseek.NewClient(os.Getenv("PROVIDER_API_KEY"), baseURL)
 
@@ -169,6 +176,7 @@ func main() {
 	request := &deepseek.ChatCompletionRequest{
 		Model: deepseek.AzureDeepSeekR1,
 		// Model: deepseek.OpenRouterDeepSeekR1,
+		// Model: deepseek.MiniMaxM3,
 		Messages: []deepseek.ChatCompletionMessage{
 			{Role: deepseek.ChatMessageRoleUser, Content: "Which is the tallest mountain in the world?"},
 		},

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Before using the library, ensure you have:
 	Models: `deepseek.MiniMaxM3`, `deepseek.MiniMaxM2_7` <br/>
 	OpenAI-compatible API: `deepseek.MiniMaxBaseURL` (global), `deepseek.MiniMaxCNBaseURL` (China) <br/>
 	Anthropic-compatible API: `deepseek.MiniMaxAnthropicAPIBaseURL` (global), `deepseek.MiniMaxCNAnthropicAPIBaseURL` (China) <br/>
-	When using `NewAnthropicClient`, set `Path` to `"messages"` with an Anthropic-compatible API base URL.
+	When using `NewAnthropicClient`, set `Path` to `"/v1/messages"` with an Anthropic-compatible API base URL.
 
 - **Ollama Support** <br/>
 	Please read [Ollama Support](#ollama) for more info about this!

--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ Before using the library, ensure you have:
 	Usage: `Model: deepseek.OpenRouterDeepSeekR1` (and other `OpenRouterDeepSeek*` constants)
 
 - **MiniMax** <br/>
-	MiniMax exposes an OpenAI-compatible endpoint (`https://api.minimax.io/v1/`). <br/>
-	Usage: `Model: deepseek.MiniMaxM3`
+	Models: `deepseek.MiniMaxM3`, `deepseek.MiniMaxM2_7` <br/>
+	OpenAI-compatible API: `deepseek.MiniMaxBaseURL` (global), `deepseek.MiniMaxCNBaseURL` (China) <br/>
+	Anthropic-compatible API: `deepseek.MiniMaxAnthropicAPIBaseURL` (global), `deepseek.MiniMaxCNAnthropicAPIBaseURL` (China) <br/>
+	When using `NewAnthropicClient`, set `Path` to `"messages"` with an Anthropic-compatible API base URL.
 
 - **Ollama Support** <br/>
 	Please read [Ollama Support](#ollama) for more info about this!
@@ -166,8 +168,11 @@ func main() {
 	// OpenRouter
 	// baseURL := "https://openrouter.ai/api/v1/"
 
-	// MiniMax
-	// baseURL := "https://api.minimax.io/v1/"
+	// MiniMax (global)
+	// baseURL := deepseek.MiniMaxBaseURL
+
+	// MiniMax (China)
+	// baseURL := deepseek.MiniMaxCNBaseURL
 
 	// Set up the Deepseek client
     client := deepseek.NewClient(os.Getenv("PROVIDER_API_KEY"), baseURL)
@@ -177,6 +182,7 @@ func main() {
 		Model: deepseek.AzureDeepSeekR1,
 		// Model: deepseek.OpenRouterDeepSeekR1,
 		// Model: deepseek.MiniMaxM3,
+		// Model: deepseek.MiniMaxM2_7,
 		Messages: []deepseek.ChatCompletionMessage{
 			{Role: deepseek.ChatMessageRoleUser, Content: "Which is the tallest mountain in the world?"},
 		},

--- a/examples/00_external_providers/chat.go
+++ b/examples/00_external_providers/chat.go
@@ -23,8 +23,11 @@ func ExternalProviders() {
 	// OpenRouter
 	// baseURL := "https://openrouter.ai/api/v1/"
 
-	// MiniMax
-	// baseURL := "https://api.minimax.io/v1/"
+	// MiniMax (global)
+	// baseURL := deepseek.MiniMaxBaseURL
+
+	// MiniMax (China)
+	// baseURL := deepseek.MiniMaxCNBaseURL
 
 	// Set up the Deepseek client
 	client := deepseek.NewClient(os.Getenv("PROVIDER_API_KEY"), baseURL)
@@ -34,6 +37,7 @@ func ExternalProviders() {
 		Model: deepseek.AzureDeepSeekR1,
 		// Model: deepseek.OpenRouterDeepSeekR1,
 		// Model: deepseek.MiniMaxM3,
+		// Model: deepseek.MiniMaxM2_7,
 		Messages: []deepseek.ChatCompletionMessage{
 			{Role: deepseek.ChatMessageRoleUser, Content: "Which is the tallest mountain in the world?"},
 		},

--- a/examples/00_external_providers/chat.go
+++ b/examples/00_external_providers/chat.go
@@ -23,6 +23,9 @@ func ExternalProviders() {
 	// OpenRouter
 	// baseURL := "https://openrouter.ai/api/v1/"
 
+	// MiniMax
+	// baseURL := "https://api.minimax.io/v1/"
+
 	// Set up the Deepseek client
 	client := deepseek.NewClient(os.Getenv("PROVIDER_API_KEY"), baseURL)
 
@@ -30,6 +33,7 @@ func ExternalProviders() {
 	request := &deepseek.ChatCompletionRequest{
 		Model: deepseek.AzureDeepSeekR1,
 		// Model: deepseek.OpenRouterDeepSeekR1,
+		// Model: deepseek.MiniMaxM3,
 		Messages: []deepseek.ChatCompletionMessage{
 			{Role: deepseek.ChatMessageRoleUser, Content: "Which is the tallest mountain in the world?"},
 		},

--- a/models.go
+++ b/models.go
@@ -33,8 +33,8 @@ const (
 	MiniMaxM2_7                         = "MiniMax-M2.7"
 	MiniMaxBaseURL                      = "https://api.minimax.io/v1/"
 	MiniMaxCNBaseURL                    = "https://api.minimaxi.com/v1/"
-	MiniMaxAnthropicAPIBaseURL          = "https://api.minimax.io/anthropic/v1/"
-	MiniMaxCNAnthropicAPIBaseURL        = "https://api.minimaxi.com/anthropic/v1/"
+	MiniMaxAnthropicAPIBaseURL          = "https://api.minimax.io/anthropic"
+	MiniMaxCNAnthropicAPIBaseURL        = "https://api.minimaxi.com/anthropic"
 )
 
 // Model represents a model that can be used with the API

--- a/models.go
+++ b/models.go
@@ -30,6 +30,11 @@ const (
 	OpenRouterDeepSeekR1DistillQwen1_5B = "deepseek/deepseek-r1-distill-qwen-1.5b" // DeepSeek R1 Distill Qwen 1.5B
 	OpenRouterDeepSeekR1DistillQwen32B  = "deepseek/deepseek-r1-distill-qwen-32b"  // DeepSeek R1 Distill Qwen 32B
 	MiniMaxM3                           = "MiniMax-M3"                             // MiniMax M3 via the OpenAI-compatible endpoint (https://api.minimax.io/v1/)
+	MiniMaxM2_7                         = "MiniMax-M2.7"
+	MiniMaxBaseURL                      = "https://api.minimax.io/v1/"
+	MiniMaxCNBaseURL                    = "https://api.minimaxi.com/v1/"
+	MiniMaxAnthropicAPIBaseURL          = "https://api.minimax.io/anthropic/v1/"
+	MiniMaxCNAnthropicAPIBaseURL        = "https://api.minimaxi.com/anthropic/v1/"
 )
 
 // Model represents a model that can be used with the API

--- a/models.go
+++ b/models.go
@@ -29,6 +29,7 @@ const (
 	OpenRouterDeepSeekR1DistillQwen14B  = "deepseek/deepseek-r1-distill-qwen-14b"  // DeepSeek R1 Distill Qwen 14B
 	OpenRouterDeepSeekR1DistillQwen1_5B = "deepseek/deepseek-r1-distill-qwen-1.5b" // DeepSeek R1 Distill Qwen 1.5B
 	OpenRouterDeepSeekR1DistillQwen32B  = "deepseek/deepseek-r1-distill-qwen-32b"  // DeepSeek R1 Distill Qwen 32B
+	MiniMaxM3                           = "MiniMax-M3"                             // MiniMax M3 via the OpenAI-compatible endpoint (https://api.minimax.io/v1/)
 )
 
 // Model represents a model that can be used with the API

--- a/models_test.go
+++ b/models_test.go
@@ -2,6 +2,9 @@ package deepseek_test
 
 import (
 	"context"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/cohesion-org/deepseek-go"
@@ -9,6 +12,93 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type requestCaptureFunc func(*http.Request) (*http.Response, error)
+
+func (f requestCaptureFunc) Do(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestMiniMaxProviderConstantsAndEndpoints(t *testing.T) {
+	require.Equal(t, "MiniMax-M3", deepseek.MiniMaxM3)
+	require.Equal(t, "MiniMax-M2.7", deepseek.MiniMaxM2_7)
+
+	tests := []struct {
+		name        string
+		baseURL     string
+		expectedURL string
+		anthropic   bool
+	}{
+		{
+			name:        "global OpenAI endpoint",
+			baseURL:     deepseek.MiniMaxBaseURL,
+			expectedURL: "https://api.minimax.io/v1/chat/completions",
+		},
+		{
+			name:        "China OpenAI endpoint",
+			baseURL:     deepseek.MiniMaxCNBaseURL,
+			expectedURL: "https://api.minimaxi.com/v1/chat/completions",
+		},
+		{
+			name:        "global Anthropic endpoint",
+			baseURL:     deepseek.MiniMaxAnthropicAPIBaseURL,
+			expectedURL: "https://api.minimax.io/anthropic/v1/messages",
+			anthropic:   true,
+		},
+		{
+			name:        "China Anthropic endpoint",
+			baseURL:     deepseek.MiniMaxCNAnthropicAPIBaseURL,
+			expectedURL: "https://api.minimaxi.com/anthropic/v1/messages",
+			anthropic:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			capture := requestCaptureFunc(func(req *http.Request) (*http.Response, error) {
+				require.Equal(t, tt.expectedURL, req.URL.String())
+
+				body := `{"id":"chatcmpl-test","object":"chat.completion","choices":[{"index":0,"message":{"role":"assistant","content":"Hello"},"finish_reason":"stop"}],"model":"MiniMax-M3","usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+				if tt.anthropic {
+					body = `{"id":"msg-test","type":"message","role":"assistant","content":[],"model":"MiniMax-M3","usage":{"input_tokens":1,"output_tokens":1}}`
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Request:    req,
+				}, nil
+			})
+
+			if tt.anthropic {
+				client := deepseek.NewAnthropicClient("test-token")
+				client.BaseURL = tt.baseURL
+				client.Path = "/v1/messages"
+				client.HTTPClient = capture
+				_, err := client.CreateAnthropicMessage(context.Background(), &deepseek.AnthropicRequest{
+					Model:     deepseek.MiniMaxM3,
+					MaxTokens: 16,
+					Messages: []deepseek.AnthropicMessage{
+						{Role: "user", Content: []interface{}{deepseek.AnthropicTextBlock{Type: "text", Text: "Hello"}}},
+					},
+				})
+				require.NoError(t, err)
+				return
+			}
+
+			client := deepseek.NewClient("test-token", tt.baseURL)
+			client.HTTPClient = capture
+			_, err := client.CreateChatCompletion(context.Background(), &deepseek.ChatCompletionRequest{
+				Model: deepseek.MiniMaxM3,
+				Messages: []deepseek.ChatCompletionMessage{
+					{Role: deepseek.ChatMessageRoleUser, Content: "Hello"},
+				},
+			})
+			require.NoError(t, err)
+		})
+	}
+}
 
 func TestListAllModels(t *testing.T) {
 	server := testutil.NewMockDeepSeekServer(t)


### PR DESCRIPTION
## Summary

Add MiniMax as an external provider with current model and regional endpoint constants.

## Changes

- Add model constants for `MiniMax-M3` and `MiniMax-M2.7`
- Add OpenAI-compatible base URL constants for the global and China regions
- Add raw Anthropic-compatible API base URL constants for the global and China regions
- Document the constants in the README and external-provider example
- Add request-capture tests for both protocols and regions

## Validation

- `go build ./...`
- `go vet ./...`
- `go test -count=1 ./...`
- `make test`
